### PR TITLE
ci(dependabot): update reviewers and assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
     reviewers:
       - amimart
       - ccamel
@@ -12,3 +12,15 @@ updates:
       - amimart
       - ccamel
       - fredericvilcot
+    open-pull-requests-limit: 5
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - ccamel
+      - fredericvilcot
+    assignees:
+      - ccamel
+      - fredericvilcot
+    open-pull-requests-limit: 5


### PR DESCRIPTION
To be compliant with other web projects, this PR:

- adds named reviewers and assignees for `npm` packages
- enhances the whole workflow