### PR TITLE
feat(ui): pull every task in a styled card & bold h3 elements

### DIFF
--- a/src/pages/tasks.tsx
+++ b/src/pages/tasks.tsx
@@ -300,9 +300,9 @@ const Tasks: NextPage<TasksProps> = props => {
         <Header typeformUrl={typeformUrl} />
         <div className="okp4-nemeton-web-page-content-container" id="tasks">
           <h1>Sidh - Tasks</h1>
-          <ol>
+          <ol style={{ display: 'flex', flexDirection: 'column', gap: '40px' }}>
             {sidhTasks.map((sidhTask: SidhTask, index: number) => (
-              <React.Fragment key={index}>
+              <div className="okp4-nemeton-web-page-content-card-container" key={index}>
                 <li>
                   <h2>{sidhTask.name}</h2>
                 </li>
@@ -311,7 +311,7 @@ const Tasks: NextPage<TasksProps> = props => {
                     <ContentBlock description={description} icon={icon} key={index} title={title} />
                   )
                 )}
-              </React.Fragment>
+              </div>
             ))}
           </ol>
         </div>

--- a/src/pages/tasks.tsx
+++ b/src/pages/tasks.tsx
@@ -72,7 +72,7 @@ const sidhTasks: SidhTask[] = [
       },
       {
         title: 'Rewards',
-        description: <p style={{ fontFamily: 'Gotham bold, sans-serif' }}>1000 points.</p>,
+        description: <p>1000 points.</p>,
         icon: <MoneyIcon />
       },
       {
@@ -120,7 +120,7 @@ const sidhTasks: SidhTask[] = [
       },
       {
         title: 'Rewards',
-        description: <p style={{ fontFamily: 'Gotham bold, sans-serif' }}>2000 points.</p>,
+        description: <p>2000 points.</p>,
         icon: <MoneyIcon />
       },
       {
@@ -152,9 +152,7 @@ const sidhTasks: SidhTask[] = [
       {
         title: 'Rewards',
         description: (
-          <p style={{ fontFamily: 'Gotham bold, sans-serif' }}>
-            Up to 2500 points with the following formula: 2501^0,01x - 1 with x = %uptime.
-          </p>
+          <p>Up to 2500 points with the following formula: 2501^0,01x - 1 with x = %uptime.</p>
         ),
         icon: <MoneyIcon />
       },
@@ -197,7 +195,7 @@ const sidhTasks: SidhTask[] = [
       },
       {
         title: 'Rewards',
-        description: <p style={{ fontFamily: 'Gotham bold, sans-serif' }}>500 points.</p>,
+        description: <p>500 points.</p>,
         icon: <MoneyIcon />
       },
       {
@@ -250,7 +248,7 @@ const sidhTasks: SidhTask[] = [
       {
         title: 'Rewards',
         description: (
-          <p style={{ fontFamily: 'Gotham bold, sans-serif' }}>
+          <p>
             Up to 10 000 points per druid will be attributed, capped at 150 000 points in total.
           </p>
         ),

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -190,20 +190,27 @@ main {
       }
     }
 
-    .content-block-main {
-      margin: 50px 0;
+    .okp4-nemeton-web-page-content-card-container {
+      background-image: linear-gradient(90deg, hsla(0, 0%, 100%, 0.1), hsla(0, 0%, 100%, 0));
+      padding: 10px 30px;
+      border-radius: 16px;
 
-      .content-block-title-container {
-        display: flex;
-        align-items: center;
-        gap: 5px;
+      .content-block-main {
+        margin: 50px 0;
 
-        > h3:first-of-type {
-          font-style: italic;
-        }
+        .content-block-title-container {
+          display: flex;
+          align-items: center;
+          gap: 5px;
 
-        > svg {
-          font-size: 28px;
+          > h3:first-of-type {
+            font-style: italic;
+            font-family: 'Gotham bold', sans-serif;
+          }
+
+          > svg {
+            font-size: 30px;
+          }
         }
       }
     }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -205,7 +205,9 @@ main {
 
           > h3:first-of-type {
             font-style: italic;
-            font-family: 'Gotham bold', sans-serif;
+            font-family: 'Gotham', sans-serif;
+            font-weight: 700;
+            padding-top: 18px;
           }
 
           > svg {


### PR DESCRIPTION
Because of @bot-anik that has closed #23, the aim of this PR is to "beautify" the tasks page in a extra fast way by putting each task in a styled card, as done for the leaderboard elements.

Here are two videos:

desktop 1440px:
https://user-images.githubusercontent.com/47554752/205330376-6b8ca2bf-7bdb-4607-81ea-9f804802a106.mov

iPhone 12 Pro:
https://user-images.githubusercontent.com/47554752/205330439-c1f38b59-6887-4db1-88b4-22dbb13740be.mov

Just tell me if you think this improvement should be deployed in production.