### PR TITLE
Fix/challenges & rewards style

### DIFF
--- a/src/components/countdown/countdown.scss
+++ b/src/components/countdown/countdown.scss
@@ -25,9 +25,6 @@
     }
 
     .okp4-nemeton-web-stat-key {
-      font-family: 'Gotham';
-      font-style: normal;
-      font-weight: 400;
       font-size: 10px;
       line-height: 10px;
       opacity: 0.6;

--- a/src/components/sidh/challenges.scss
+++ b/src/components/sidh/challenges.scss
@@ -129,7 +129,7 @@
             font-size: 20px;
 
             &:nth-child(2) {
-              text-align: right;
+              white-space: nowrap;
               font-family: 'Gotham bold', sans-serif;
             }
 


### PR DESCRIPTION
This PR fixes the safari visual bug in the countdown and adds a nowrap to 'pts' in rewards

<details>
<summary>challenges</summary>

- before
![Capture d’écran 2022-12-06 à 09 19 10](https://user-images.githubusercontent.com/75730728/205863083-2983239b-f85b-4375-98c4-1d0a732798dd.png)

- after
![Capture d’écran 2022-12-06 à 09 19 22](https://user-images.githubusercontent.com/75730728/205863079-e3d62d26-b569-4f05-8581-3d148f9c6e8a.png)

</details>

<details>
<summary>rewards</summary>

With 390px width:
- before
![Capture d’écran 2022-12-06 à 09 22 06](https://user-images.githubusercontent.com/75730728/205862126-9a5f2d25-c112-469d-bd63-43b92a74d7fa.png)

- after
![Capture d’écran 2022-12-06 à 09 22 29](https://user-images.githubusercontent.com/75730728/205862134-bb9cd8cc-f704-416f-841d-26b69605b76d.png)

</details>