### PR TITLE
style(leaderboard): improve phase card text wrap

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -313,6 +313,7 @@ main {
 
   .okp4-nemeton-web-page-leaderboard-summary-card-title-container {
     display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
     gap: 10px;
 
@@ -321,11 +322,16 @@ main {
       margin: 0;
       letter-spacing: 0.04em;
       text-shadow: unset;
+      white-space: nowrap;
     }
   }
 
   .okp4-nemeton-web-page-leaderboard-summary-card-title {
     font-size: 61px !important;
+
+    &:is(h1) {
+      line-height: 57px;
+    }
 
     &.uppercase {
       text-transform: uppercase;


### PR DESCRIPTION
This PR improves the leaderboard phase card by not allowing the phase text to wrap and instead wraps the title container content

Before:
![Capture d’écran 2023-04-01 à 19 21 10](https://user-images.githubusercontent.com/75730728/229305508-f3341051-a56f-4c2b-bd33-026281ac4138.png)

After:
![Capture d’écran 2023-04-01 à 19 21 05](https://user-images.githubusercontent.com/75730728/229305511-2bf43fdf-a7f2-4eba-b78c-5da621d3c6c9.png)
