### PR TITLE
style: improve druid rank number style

### DIFF
--- a/src/components/table/builders/leaderboardTable.scss
+++ b/src/components/table/builders/leaderboardTable.scss
@@ -133,6 +133,10 @@ $podium-colors: ('gold', 'silver', 'bronze');
               padding-left: 41px;
 
               @media screen and (max-width: 1000px) {
+                padding-left: 35px;
+              }
+
+              @media screen and (max-width: 580px) {
                 padding-left: 15px;
               }
             }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -150,6 +150,10 @@ $podium-colors: ('gold', 'silver', 'bronze');
               padding-left: 41px;
 
               @media screen and (max-width: 1000px) {
+                padding-left: 30px;
+              }
+
+              @media screen and (max-width: 580px) {
                 padding-left: 15px;
               }
             }


### PR DESCRIPTION
This PR fix the druid rank number style for Leaderboard and Results pages on tablet screen.

<details>

![Screenshot 2023-08-28 at 18 07 45](https://github.com/okp4/nemeton-web/assets/93918596/d36280e2-a1aa-45e8-965f-b14af5948972)

<summary> Screenshots </summary>
