### PR TITLE
ci: fix version of changelog conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
             @semantic-release/git
             @semantic-release/npm
           extends: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}


### PR DESCRIPTION
Same than [nemeton-leaderboard](https://github.com/okp4/nemeton-leaderboard/pull/192). 

See https://github.com/semantic-release/commit-analyzer/issues/517 for more details